### PR TITLE
reservation UI

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name="com.parking_system_kotlin.activities.ReservationActivity"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/parking_system_kotlin/activities/MainActivity.kt
+++ b/app/src/main/java/com/parking_system_kotlin/activities/MainActivity.kt
@@ -2,12 +2,12 @@ package com.parking_system_kotlin.activities
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import com.parking_system_kotlin.listeners.ListenerSetParkingDialogFragment
 import com.parking_system_kotlin.mvp.contracts.ParkingContract
 import com.parking_system_kotlin.mvp.model.ParkingModel
 import com.parking_system_kotlin.mvp.presenter.ParkingPresenter
 import com.parking_system_kotlin.mvp.view.ParkingView
 import com.parkingsystemkotlin.databinding.ActivityMainBinding
-import com.parking_system_kotlin.listeners.ListenerSetParkingDialogFragment
 
 class MainActivity : AppCompatActivity(), ListenerSetParkingDialogFragment {
     private lateinit var presenter: ParkingContract.MainActivityPresenter
@@ -24,7 +24,10 @@ class MainActivity : AppCompatActivity(), ListenerSetParkingDialogFragment {
     }
 
     private fun setListeners() {
-        binding.buttonMainActivitySelectParkingSpace.setOnClickListener { presenter.onSetParkingButtonPressed(this) }
+        with(binding) {
+            buttonMainActivitySelectParkingSpace.setOnClickListener { presenter.onSetParkingButtonPressed(this@MainActivity) }
+            buttonMainActivityReservation.setOnClickListener { presenter.onReservationButtonPressed() }
+        }
     }
 
     override fun listenFreeSpaces(freeSpaces: String) {

--- a/app/src/main/java/com/parking_system_kotlin/activities/ReservationActivity.kt
+++ b/app/src/main/java/com/parking_system_kotlin/activities/ReservationActivity.kt
@@ -1,0 +1,49 @@
+package com.parking_system_kotlin.activities
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.parking_system_kotlin.listeners.ListenerDateTime
+import com.parking_system_kotlin.mvp.contracts.ParkingReservationContract
+import com.parking_system_kotlin.mvp.presenter.ParkingReservationPresenter
+import com.parking_system_kotlin.mvp.view.ParkingReservationView
+import com.parkingsystemkotlin.databinding.ActivityReservationBinding
+import java.util.Calendar
+
+class ReservationActivity : AppCompatActivity(), ListenerDateTime {
+
+    private lateinit var binding: ActivityReservationBinding
+    private lateinit var presenter: ParkingReservationContract.ParkingReservationPresenter
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityReservationBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        presenter = ParkingReservationPresenter(ParkingReservationView(this, binding))
+
+        setListeners()
+    }
+
+    private fun setListeners() {
+        with(binding) {
+            editTextReservationActivityEntry.setOnClickListener { presenter.showDatePicker(this@ReservationActivity, true) }
+            editTextReservationActivityExit.setOnClickListener { presenter.showDatePicker(this@ReservationActivity, false) }
+            buttonReservationActivitySave.setOnClickListener {
+                presenter.saveReservation()
+            }
+        }
+    }
+
+    override fun setEntryDate(entryDate: Calendar) {
+        presenter.setEntryDate(entryDate)
+    }
+
+    override fun setExitDate(exitDate: Calendar) {
+        presenter.setExitDate(exitDate)
+    }
+
+    companion object {
+        fun newInstance(context: Context): Intent = Intent(context, ReservationActivity::class.java)
+    }
+}

--- a/app/src/main/java/com/parking_system_kotlin/fragments/DateReservationDialogFragment.kt
+++ b/app/src/main/java/com/parking_system_kotlin/fragments/DateReservationDialogFragment.kt
@@ -1,0 +1,55 @@
+package com.parking_system_kotlin.fragments
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.DialogFragment
+import com.parking_system_kotlin.listeners.ListenerDateTime
+import com.parking_system_kotlin.mvp.contracts.ParkingDatePickerContract
+import com.parking_system_kotlin.mvp.presenter.ParkingDatePickerPresenter
+import com.parking_system_kotlin.mvp.view.ParkingDatePickerView
+import com.parking_system_kotlin.utils.Constants
+import com.parkingsystemkotlin.databinding.DialogFragmentDatePickerBinding
+
+class DateReservationDialogFragment : DialogFragment() {
+
+    private lateinit var binding: DialogFragmentDatePickerBinding
+    private lateinit var presenter: ParkingDatePickerContract.ParkingDatePickerPresenter
+    private lateinit var listenerDateTime: ListenerDateTime
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        super.onCreateView(inflater, container, savedInstanceState)
+        binding = DialogFragmentDatePickerBinding.inflate(inflater, container, false)
+        presenter = ParkingDatePickerPresenter(
+            ParkingDatePickerView(this, binding),
+            arguments?.getBoolean(Constants.DATE_SELECTOR_BOOLEAN)
+        )
+
+        listenerDateTime = arguments?.getSerializable(Constants.LISTENER_DATE_PICKER_KEY) as ListenerDateTime
+        setListeners()
+        return binding.root
+    }
+
+    companion object {
+        fun newInstance(listenerDateTime: ListenerDateTime, dateSelector: Boolean): DateReservationDialogFragment {
+            val entryReservationDialogFragment = DateReservationDialogFragment()
+            val bundle = Bundle()
+            bundle.apply {
+                putBoolean(Constants.DATE_SELECTOR_BOOLEAN, dateSelector)
+                putSerializable(Constants.LISTENER_DATE_PICKER_KEY, listenerDateTime)
+            }
+            entryReservationDialogFragment.arguments = bundle
+            return entryReservationDialogFragment
+        }
+    }
+
+    private fun setListeners() {
+        binding.buttonReservationDialogFragmentConfirm.setOnClickListener {
+            presenter.onButtonDialogFragmentDatePickerConfirmationPressed(
+                listenerDateTime
+            )
+        }
+        binding.buttonReservationDialogFragmentCancel.setOnClickListener { presenter.closeDateDialog() }
+    }
+}

--- a/app/src/main/java/com/parking_system_kotlin/fragments/SpacesSettingDialogFragment.kt
+++ b/app/src/main/java/com/parking_system_kotlin/fragments/SpacesSettingDialogFragment.kt
@@ -5,12 +5,12 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
+import com.parking_system_kotlin.listeners.ListenerSetParkingDialogFragment
 import com.parking_system_kotlin.mvp.contracts.ParkingSpacesSettingContract
 import com.parking_system_kotlin.mvp.presenter.ParkingSpacesSettingPresenter
 import com.parking_system_kotlin.mvp.view.ParkingSpacesSettingView
 import com.parking_system_kotlin.utils.Constants
 import com.parkingsystemkotlin.databinding.DialogFragmentParkingSpacesSettingBinding
-import com.parking_system_kotlin.listeners.ListenerSetParkingDialogFragment
 
 class SpacesSettingDialogFragment : DialogFragment() {
     private lateinit var presenter: ParkingSpacesSettingContract.ParkingSpacesSettingDialogFragmentPresenter

--- a/app/src/main/java/com/parking_system_kotlin/listeners/ListenerDateTime.kt
+++ b/app/src/main/java/com/parking_system_kotlin/listeners/ListenerDateTime.kt
@@ -1,0 +1,9 @@
+package com.parking_system_kotlin.listeners
+
+import java.io.Serializable
+import java.util.Calendar
+
+interface ListenerDateTime : Serializable {
+    fun setEntryDate(entryDate: Calendar)
+    fun setExitDate(exitDate: Calendar)
+}

--- a/app/src/main/java/com/parking_system_kotlin/mvp/contracts/ParkingContract.kt
+++ b/app/src/main/java/com/parking_system_kotlin/mvp/contracts/ParkingContract.kt
@@ -12,10 +12,12 @@ interface ParkingContract {
     interface MainActivityPresenter {
         fun onSetParkingButtonPressed(listenerSetParkingDialogFragment: ListenerSetParkingDialogFragment)
         fun setParkingSpacesAvailable(spacesAvailable: String)
+        fun onReservationButtonPressed()
     }
 
     interface MainActivityView {
         fun showDialogFragment(listenerSetParkingDialogFragment: ListenerSetParkingDialogFragment)
         fun showParkingLotsAvailable(parkingLots: String)
+        fun showReservationActivity()
     }
 }

--- a/app/src/main/java/com/parking_system_kotlin/mvp/contracts/ParkingDatePickerContract.kt
+++ b/app/src/main/java/com/parking_system_kotlin/mvp/contracts/ParkingDatePickerContract.kt
@@ -1,0 +1,17 @@
+package com.parking_system_kotlin.mvp.contracts
+
+import com.parking_system_kotlin.listeners.ListenerDateTime
+
+interface ParkingDatePickerContract {
+
+    interface ParkingDatePickerPresenter {
+        fun onButtonDialogFragmentDatePickerConfirmationPressed(listenerDateTime: ListenerDateTime)
+        fun closeDateDialog()
+    }
+
+    interface ParkingDatePickerView {
+        fun showEntryReservationDate(listenerDateTime: ListenerDateTime)
+        fun showExitReservationDate(listenerDateTime: ListenerDateTime)
+        fun closeDateDialog()
+    }
+}

--- a/app/src/main/java/com/parking_system_kotlin/mvp/contracts/ParkingReservationContract.kt
+++ b/app/src/main/java/com/parking_system_kotlin/mvp/contracts/ParkingReservationContract.kt
@@ -1,0 +1,22 @@
+package com.parking_system_kotlin.mvp.contracts
+
+import com.parking_system_kotlin.listeners.ListenerDateTime
+import java.util.Calendar
+
+
+interface ParkingReservationContract {
+
+    interface ParkingReservationPresenter {
+        fun showDatePicker(listenerDateTime: ListenerDateTime, dateSelector: Boolean)
+        fun setEntryDate(entryDate: Calendar)
+        fun setExitDate(exitDate: Calendar)
+        fun saveReservation()
+    }
+
+    interface ParkingReservationView {
+        fun showDatePicker(listenerDateTime: ListenerDateTime, dateSelector: Boolean)
+        fun showEntryDateSelected(date: String)
+        fun showExitDateSelected(date: String)
+        fun closeScreen()
+    }
+}

--- a/app/src/main/java/com/parking_system_kotlin/mvp/presenter/ParkingDatePickerPresenter.kt
+++ b/app/src/main/java/com/parking_system_kotlin/mvp/presenter/ParkingDatePickerPresenter.kt
@@ -1,0 +1,20 @@
+package com.parking_system_kotlin.mvp.presenter
+
+import com.parking_system_kotlin.listeners.ListenerDateTime
+import com.parking_system_kotlin.mvp.contracts.ParkingDatePickerContract
+
+class ParkingDatePickerPresenter(private var view: ParkingDatePickerContract.ParkingDatePickerView, private val dateSelector: Boolean?) :
+    ParkingDatePickerContract.ParkingDatePickerPresenter {
+
+    override fun onButtonDialogFragmentDatePickerConfirmationPressed(listenerDateTime: ListenerDateTime) {
+        if (dateSelector == true) {
+            view.showEntryReservationDate(listenerDateTime)
+        } else {
+            view.showExitReservationDate(listenerDateTime)
+        }
+    }
+
+    override fun closeDateDialog() {
+        view.closeDateDialog()
+    }
+}

--- a/app/src/main/java/com/parking_system_kotlin/mvp/presenter/ParkingPresenter.kt
+++ b/app/src/main/java/com/parking_system_kotlin/mvp/presenter/ParkingPresenter.kt
@@ -14,4 +14,8 @@ class ParkingPresenter(private val model: ParkingContract.MainActivityModel, pri
         model.setParkingLots(spacesAvailable)
         view.showParkingLotsAvailable(model.getParkingLots())
     }
+
+    override fun onReservationButtonPressed() {
+        view.showReservationActivity()
+    }
 }

--- a/app/src/main/java/com/parking_system_kotlin/mvp/presenter/ParkingReservationPresenter.kt
+++ b/app/src/main/java/com/parking_system_kotlin/mvp/presenter/ParkingReservationPresenter.kt
@@ -1,0 +1,26 @@
+package com.parking_system_kotlin.mvp.presenter
+
+import com.parking_system_kotlin.listeners.ListenerDateTime
+import com.parking_system_kotlin.mvp.contracts.ParkingReservationContract
+import com.parking_system_kotlin.utils.getStringFromDate
+import java.util.Calendar
+
+class ParkingReservationPresenter(private val view: ParkingReservationContract.ParkingReservationView) :
+    ParkingReservationContract.ParkingReservationPresenter {
+
+    override fun showDatePicker(listenerDateTime: ListenerDateTime, dateSelector: Boolean) {
+        view.showDatePicker(listenerDateTime, dateSelector)
+    }
+
+    override fun setEntryDate(entryDate: Calendar) {
+        view.showEntryDateSelected(entryDate.getStringFromDate())
+    }
+
+    override fun setExitDate(exitDate: Calendar) {
+        view.showExitDateSelected(exitDate.getStringFromDate())
+    }
+
+    override fun saveReservation() {
+        view.closeScreen()
+    }
+}

--- a/app/src/main/java/com/parking_system_kotlin/mvp/presenter/ParkingSpacesSettingPresenter.kt
+++ b/app/src/main/java/com/parking_system_kotlin/mvp/presenter/ParkingSpacesSettingPresenter.kt
@@ -3,9 +3,8 @@ package com.parking_system_kotlin.mvp.presenter
 import com.parking_system_kotlin.listeners.ListenerSetParkingDialogFragment
 import com.parking_system_kotlin.mvp.contracts.ParkingSpacesSettingContract
 
-class ParkingSpacesSettingPresenter(view: ParkingSpacesSettingContract.ParkingSpacesSettingDialogFragmentView) :
+class ParkingSpacesSettingPresenter(private val view: ParkingSpacesSettingContract.ParkingSpacesSettingDialogFragmentView) :
     ParkingSpacesSettingContract.ParkingSpacesSettingDialogFragmentPresenter {
-    private var view: ParkingSpacesSettingContract.ParkingSpacesSettingDialogFragmentView = view
 
     override fun onButtonDialogFragmentSpacesSettingConfirmationPressed(
         freeSpaces: String,

--- a/app/src/main/java/com/parking_system_kotlin/mvp/view/ParkingDatePickerView.kt
+++ b/app/src/main/java/com/parking_system_kotlin/mvp/view/ParkingDatePickerView.kt
@@ -1,0 +1,41 @@
+package com.parking_system_kotlin.mvp.view
+
+import androidx.fragment.app.Fragment
+import com.parking_system_kotlin.fragments.DateReservationDialogFragment
+import com.parking_system_kotlin.listeners.ListenerDateTime
+import com.parking_system_kotlin.mvp.contracts.ParkingDatePickerContract
+import com.parking_system_kotlin.mvp.view.base.FragmentView
+import com.parkingsystemkotlin.databinding.DialogFragmentDatePickerBinding
+import java.util.Calendar
+import java.util.GregorianCalendar
+
+class ParkingDatePickerView(fragment: Fragment, private val binding: DialogFragmentDatePickerBinding) :
+    ParkingDatePickerContract.ParkingDatePickerView, FragmentView(fragment) {
+
+    private fun getCalentar(): Calendar {
+        val fragment: DateReservationDialogFragment = fragment as DateReservationDialogFragment
+        val calendar: Calendar = GregorianCalendar()
+        calendar.set(
+            binding.datePickerDialogFragment.year,
+            binding.datePickerDialogFragment.month,
+            binding.datePickerDialogFragment.dayOfMonth,
+            binding.timePickerDialogFragment.hour,
+            binding.timePickerDialogFragment.minute
+        )
+        fragment.dismiss()
+        return calendar
+    }
+
+    override fun showEntryReservationDate(listenerDateTime: ListenerDateTime) {
+        listenerDateTime.setEntryDate(getCalentar())
+    }
+
+    override fun showExitReservationDate(listenerDateTime: ListenerDateTime) {
+        listenerDateTime.setExitDate(getCalentar())
+    }
+
+    override fun closeDateDialog() {
+        val dialogFragment: DateReservationDialogFragment = fragment as DateReservationDialogFragment
+        dialogFragment.dismiss()
+    }
+}

--- a/app/src/main/java/com/parking_system_kotlin/mvp/view/ParkingReservationView.kt
+++ b/app/src/main/java/com/parking_system_kotlin/mvp/view/ParkingReservationView.kt
@@ -1,0 +1,31 @@
+package com.parking_system_kotlin.mvp.view
+
+import android.app.Activity
+import com.parking_system_kotlin.fragments.DateReservationDialogFragment
+import com.parking_system_kotlin.listeners.ListenerDateTime
+import com.parking_system_kotlin.mvp.contracts.ParkingReservationContract
+import com.parking_system_kotlin.mvp.view.base.ActivityView
+import com.parking_system_kotlin.utils.Constants
+import com.parkingsystemkotlin.databinding.ActivityReservationBinding
+
+class ParkingReservationView(activity: Activity, private val binding: ActivityReservationBinding) : ActivityView(activity),
+    ParkingReservationContract.ParkingReservationView {
+
+    override fun showDatePicker(listenerDateTime: ListenerDateTime, dateSelector: Boolean) {
+        fragmentManager?.let {
+            DateReservationDialogFragment.newInstance(listenerDateTime, dateSelector).show(it, Constants.DIALOG_FRAGMENT_ENTRY_DATE_PICKER)
+        }
+    }
+
+    override fun showEntryDateSelected(date: String) {
+        binding.editTextReservationActivityEntry.setText(date)
+    }
+
+    override fun showExitDateSelected(date: String) {
+        binding.editTextReservationActivityExit.setText(date)
+    }
+
+    override fun closeScreen() {
+        activity?.finish()
+    }
+}

--- a/app/src/main/java/com/parking_system_kotlin/mvp/view/ParkingSpacesSettingView.kt
+++ b/app/src/main/java/com/parking_system_kotlin/mvp/view/ParkingSpacesSettingView.kt
@@ -12,7 +12,7 @@ class ParkingSpacesSettingView(fragment: SpacesSettingDialogFragment) : Fragment
 
     override fun showParkingLotsAvailable(parkingLots: String, listenerSetParkingDialogFragment: ListenerSetParkingDialogFragment) {
         val fragment: SpacesSettingDialogFragment = fragment as SpacesSettingDialogFragment
-        fragment?.dismiss()
+        fragment.dismiss()
         listenerSetParkingDialogFragment.listenFreeSpaces(parkingLots)
     }
 

--- a/app/src/main/java/com/parking_system_kotlin/mvp/view/ParkingView.kt
+++ b/app/src/main/java/com/parking_system_kotlin/mvp/view/ParkingView.kt
@@ -2,6 +2,7 @@ package com.parking_system_kotlin.mvp.view
 
 import android.app.Activity
 import android.widget.Toast
+import com.parking_system_kotlin.activities.ReservationActivity
 import com.parking_system_kotlin.fragments.SpacesSettingDialogFragment
 import com.parking_system_kotlin.listeners.ListenerSetParkingDialogFragment
 import com.parking_system_kotlin.mvp.contracts.ParkingContract
@@ -21,6 +22,15 @@ class ParkingView(activity: Activity) : ActivityView(activity), ParkingContract.
         context?.let {
             Toast.makeText(it, it?.getString(R.string.main_activity_toast_set_parking_lots, parkingLots), Toast.LENGTH_LONG)
                 .show()
+        }
+    }
+
+    override fun showReservationActivity() {
+        activity?.let { activity ->
+            context?.let {
+                val intent = ReservationActivity.newInstance(it)
+                activity.startActivity(intent)
+            }
         }
     }
 }

--- a/app/src/main/java/com/parking_system_kotlin/utils/Constants.kt
+++ b/app/src/main/java/com/parking_system_kotlin/utils/Constants.kt
@@ -3,4 +3,9 @@ package com.parking_system_kotlin.utils
 object Constants {
     const val LISTENER_SPACES_SETTING_KEY: String = "LISTENER_SPACES_SETTING_KEY"
     const val DIALOG_SPACES_SPACES_SETTING: String = "DIALOG_SPACES_SPACES_SETTING"
+    const val LISTENER_DATE_PICKER_KEY: String = "LISTENER_DATE_PICKER_KEY";
+    const val DATE_SELECTOR_BOOLEAN: String = "DATE_SELECTOR_BOOLEAN";
+    const val DIALOG_FRAGMENT_ENTRY_DATE_PICKER: String = "DIALOG_FRAGMENT_ENTRY_DATE_PICKER"
+    const val DATE_FORMAT = "dd-MMM-yyyy a hh:mm"
+    const val EMPTY_STRING = ""
 }

--- a/app/src/main/java/com/parking_system_kotlin/utils/Utils.kt
+++ b/app/src/main/java/com/parking_system_kotlin/utils/Utils.kt
@@ -1,0 +1,31 @@
+package com.parking_system_kotlin.utils
+
+import java.text.ParseException
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+
+fun Calendar.getStringFromDate(): String {
+    var inActiveDate: String = Constants.EMPTY_STRING
+    try {
+        inActiveDate = SimpleDateFormat(Constants.DATE_FORMAT).format(this.time)
+    } catch (exception: Exception) {
+        exception.printStackTrace()
+    }
+    return inActiveDate
+}
+
+fun String.getCalendarFromString(): Calendar? {
+    if (this.isNotEmpty()) {
+        val calendar = Calendar.getInstance()
+        val date: Date
+        try {
+            val date = SimpleDateFormat(Constants.DATE_FORMAT).parse(this)
+            calendar.time = date
+        } catch (e: ParseException) {
+            e.printStackTrace()
+        }
+        return calendar
+    }
+    return null
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -15,6 +15,7 @@
         android:layout_marginTop="@dimen/text_main_activity_margin_top"
         android:text="@string/main_activity_text_title"
         app:layout_constraintTop_toTopOf="parent" />
+
     <Button
         android:id="@+id/button_main_activity_select_parking_space"
         android:backgroundTint="@color/button_main_activity_cream"
@@ -26,4 +27,12 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toBottomOf="@id/text_main_activity_title" />
 
+    <Button
+        android:id="@+id/button_main_activity_reservation"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/button_main_activity_select_parking_space"
+        android:text="@string/main_activity_button_make_reservation"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_reservation.xml
+++ b/app/src/main/res/layout/activity_reservation.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/wallpaper_main_screen">
+
+    <TextView
+        android:id="@+id/text_view_reservation_activity_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/reservation_activity_text_title"
+        android:textSize="@dimen/text_reservation_activity_title_text_size"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/text_view_reservation_activity_from_date"
+        style="@style/FromToDateReservationActivity"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/reservation_activity_text_from_date"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toLeftOf="@id/edit_text_reservation_activity_entry"
+        app:layout_constraintTop_toBottomOf="@id/text_view_reservation_activity_title" />
+
+    <EditText
+        android:id="@+id/edit_text_reservation_activity_entry"
+        style="@style/InputStyleDatePickerReservationActivity"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:hint="@string/reservation_activity_entry_hint"
+        app:layout_constraintBottom_toBottomOf="@id/text_view_reservation_activity_from_date"
+        app:layout_constraintLeft_toRightOf="@id/text_view_reservation_activity_from_date"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/text_view_reservation_activity_title"
+        app:layout_constraintTop_toTopOf="@id/text_view_reservation_activity_from_date" />
+
+    <TextView
+        android:id="@+id/text_view_reservation_activity_to_date"
+        style="@style/FromToDateReservationActivity"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/reservation_activity_text_to_date"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toLeftOf="@id/edit_text_reservation_activity_exit"
+        app:layout_constraintTop_toBottomOf="@id/text_view_reservation_activity_from_date" />
+
+    <EditText
+        android:id="@+id/edit_text_reservation_activity_exit"
+        style="@style/InputStyleDatePickerReservationActivity"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:hint="@string/reservation_activity_exit_hint"
+        app:layout_constraintBottom_toBottomOf="@id/text_view_reservation_activity_to_date"
+        app:layout_constraintLeft_toRightOf="@id/text_view_reservation_activity_to_date"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/text_view_reservation_activity_from_date"
+        app:layout_constraintTop_toTopOf="@id/text_view_reservation_activity_to_date" />
+
+    <EditText
+        android:id="@+id/edit_text_reservation_activity_parking_number"
+        style="@style/InputStyleReservationActivityParkingNumber"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:hint="@string/reservation_activity_parking_number_hint"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/edit_text_reservation_activity_exit" />
+
+    <EditText
+        android:id="@+id/edit_text_reservation_activity_code"
+        style="@style/InputStyleReservationActivityKeyCode"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:hint="@string/reservation_activity_parking_code_hint"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/edit_text_reservation_activity_parking_number" />
+
+    <Button
+        android:id="@+id/button_reservation_activity_save"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/button_reservation_fragment_save_margin_top"
+        android:text="@string/reservation_activity_button_save_text"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/edit_text_reservation_activity_code" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/dialog_fragment_date_picker.xml
+++ b/app/src/main/res/layout/dialog_fragment_date_picker.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true">
+
+    <TableLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:stretchColumns="1">
+
+        <DatePicker
+            android:id="@+id/date_picker_dialog_fragment"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:datePickerMode="calendar"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TimePicker
+            android:id="@+id/time_picker_dialog_fragment"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:timePickerMode="spinner"
+            app:layout_constraintTop_toBottomOf="@+id/date_picker_dialog_fragment" />
+
+        <Button
+            android:id="@+id/button_reservation_dialog_fragment_cancel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/dialog_fragment_date_picker_text_cancel"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toLeftOf="@id/button_reservation_dialog_fragment_confirm"
+            app:layout_constraintTop_toBottomOf="@id/time_picker_dialog_fragment" />
+
+        <Button
+            android:id="@+id/button_reservation_dialog_fragment_confirm"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/dialog_fragment_date_picker_text_confirm"
+            app:layout_constraintLeft_toRightOf="@+id/button_reservation_dialog_fragment_cancel"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/time_picker_dialog_fragment" />
+    </TableLayout>
+</ScrollView>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -9,4 +9,12 @@
     <dimen name="text_edit_dialog_fragment_spaces_setting_margin">35dp</dimen>
     <dimen name="button_dialog_fragment_spaces_setting_margin_bottom">20dp</dimen>
     <dimen name="edit_text_dialog_fragment_spaces_setting_margin_top">25dp</dimen>
+    <dimen name="text_reservation_activity_title_text_size">30sp</dimen>
+    <dimen name="button_reservation_fragment_save_margin_top">30dp</dimen>
+    <dimen name="text_reservation_activity_from_date_text_size">20sp</dimen>
+    <dimen name="text_reservation_activity_from_date_margin_top">50dp</dimen>
+    <dimen name="edit_text_reservation_activity_entry_date_text_size">20sp</dimen>
+    <dimen name="edit_text_reservation_activity_main_margin_top">25dp</dimen>
+    <dimen name="edit_text_reservation_activity_parking_number_text_size">25sp</dimen>
+    <dimen name="edit_text_reservation_activity_parking_code_text_size">30sp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,8 +2,19 @@
     <string name="app_name">ParkingSystemKotlin</string>
     <string name="main_activity_text_title">Welcome to free Spot!</string>
     <string name="main_activity_button_set_size">Set Parking spaces</string>
+    <string name="main_activity_button_make_reservation">Make a reservation</string>
     <string name="main_activity_toast_set_parking_lots">%1$s free spots.</string>
     <string name="dialog_fragment_toast_invalid_value">please insert a valid number</string>
     <string name="dialog_fragment_confirm_button">Confirm</string>
     <string name="dialog_fragment_title_text">Set spaces available:</string>
+    <string name="reservation_activity_text_title">Your reservation</string>
+    <string name="reservation_activity_text_from_date">from</string>
+    <string name="reservation_activity_entry_hint">Select entry date</string>
+    <string name="reservation_activity_text_to_date">to</string>
+    <string name="reservation_activity_exit_hint">Select exit date</string>
+    <string name="reservation_activity_parking_number_hint">Insert parking number</string>
+    <string name="reservation_activity_parking_code_hint">Insert your key code</string>
+    <string name="reservation_activity_button_save_text">Save</string>
+    <string name="dialog_fragment_date_picker_text_cancel">Cancel</string>
+    <string name="dialog_fragment_date_picker_text_confirm">Confirm</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -25,4 +25,27 @@
         <item name="android:layout_marginBottom">@dimen/button_dialog_fragment_spaces_setting_margin_bottom</item>
         <item name="android:text">@string/dialog_fragment_confirm_button</item>
     </style>
+
+    <style name="FromToDateReservationActivity">
+        <item name="android:textSize">@dimen/text_reservation_activity_from_date_text_size</item>
+        <item name="android:layout_marginTop">@dimen/text_reservation_activity_from_date_margin_top</item>
+    </style>
+
+    <style name="InputStyleDatePickerReservationActivity">
+        <item name="android:inputType">date</item>
+        <item name="android:focusable">false</item>
+        <item name="android:textSize">@dimen/edit_text_reservation_activity_entry_date_text_size</item>
+        <item name="android:clickable">true</item>
+        <item name="android:maxLines">1</item>
+    </style>
+
+    <style name="InputStyleReservationActivityParkingNumber">
+        <item name="android:layout_marginTop">@dimen/edit_text_reservation_activity_main_margin_top</item>
+        <item name="android:textSize">@dimen/edit_text_reservation_activity_parking_number_text_size</item>
+    </style>
+
+    <style name="InputStyleReservationActivityKeyCode">
+        <item name="android:textSize">@dimen/edit_text_reservation_activity_parking_code_text_size</item>
+        <item name="android:layout_marginTop">@dimen/edit_text_reservation_activity_main_margin_top</item>
+    </style>
 </resources>

--- a/app/src/test/java/com/parking_system_kotlin/presenter/ParkingDatePickerPresenterTest.kt
+++ b/app/src/test/java/com/parking_system_kotlin/presenter/ParkingDatePickerPresenterTest.kt
@@ -1,0 +1,36 @@
+package com.parking_system_kotlin.presenter
+
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import com.parking_system_kotlin.listeners.ListenerDateTime
+import com.parking_system_kotlin.mvp.contracts.ParkingDatePickerContract
+import com.parking_system_kotlin.mvp.presenter.ParkingDatePickerPresenter
+import org.junit.Test
+
+class ParkingDatePickerPresenterTest {
+    private val listener: ListenerDateTime = mock()
+    private val view: ParkingDatePickerContract.ParkingDatePickerView = mock()
+    private val presenterEntryDate: ParkingDatePickerContract.ParkingDatePickerPresenter = ParkingDatePickerPresenter(view, true)
+
+    @Test
+    fun ` show entry reservation date test `() {
+        presenterEntryDate.onButtonDialogFragmentDatePickerConfirmationPressed(listener)
+
+        verify(view).showEntryReservationDate(listener)
+    }
+
+    @Test
+    fun ` show exit reservation date test `() {
+        val presenterExitDate: ParkingDatePickerContract.ParkingDatePickerPresenter = ParkingDatePickerPresenter(view, false)
+        presenterExitDate.onButtonDialogFragmentDatePickerConfirmationPressed(listener)
+
+        verify(view).showExitReservationDate(listener)
+    }
+
+    @Test
+    fun ` close date dialog test `() {
+        presenterEntryDate.closeDateDialog()
+
+        verify(view).closeDateDialog()
+    }
+}

--- a/app/src/test/java/com/parking_system_kotlin/presenter/ParkingPresenterTest.kt
+++ b/app/src/test/java/com/parking_system_kotlin/presenter/ParkingPresenterTest.kt
@@ -30,6 +30,13 @@ class ParkingPresenterTest {
         assertEquals(FIVE_STRING, model.getParkingLots())
     }
 
+    @Test
+    fun ` on reservation button pressed test`(){
+        presenter.onReservationButtonPressed()
+
+        verify(view).showReservationActivity()
+    }
+
     companion object {
         private const val FIVE_STRING: String = "5"
     }

--- a/app/src/test/java/com/parking_system_kotlin/presenter/ParkingReservationPresenterTest.kt
+++ b/app/src/test/java/com/parking_system_kotlin/presenter/ParkingReservationPresenterTest.kt
@@ -1,0 +1,57 @@
+package com.parking_system_kotlin.presenter
+
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import com.parking_system_kotlin.listeners.ListenerDateTime
+import com.parking_system_kotlin.mvp.contracts.ParkingReservationContract
+import com.parking_system_kotlin.mvp.presenter.ParkingReservationPresenter
+import com.parking_system_kotlin.utils.getStringFromDate
+import org.junit.Test
+import java.util.Calendar
+import java.util.GregorianCalendar
+
+class ParkingReservationPresenterTest {
+    private val view: ParkingReservationContract.ParkingReservationView = mock()
+    private val presenter: ParkingReservationContract.ParkingReservationPresenter = ParkingReservationPresenter(view)
+    private val listener: ListenerDateTime = mock()
+    private val YEAR = 2021
+    private val MONTH = 8
+    private val ENTRY_DAY = 16
+    private val HOUR = 1
+    private val MINUTE = 12
+
+    private fun getCalendar(): Calendar {
+        val calendar: Calendar = GregorianCalendar()
+        calendar[YEAR, MONTH, ENTRY_DAY, HOUR] =
+            MINUTE
+        return calendar
+    }
+
+    @Test
+    fun ` show date picker test `() {
+        presenter.showDatePicker(listener, true)
+
+        verify(view).showDatePicker(listener, true)
+    }
+
+    @Test
+    fun ` set entry date test `() {
+        presenter.setEntryDate(getCalendar())
+
+        verify(view).showEntryDateSelected(getCalendar().getStringFromDate())
+    }
+
+    @Test
+    fun ` set exit date test `() {
+        presenter.setExitDate(getCalendar())
+
+        verify(view).showExitDateSelected(getCalendar().getStringFromDate())
+    }
+
+    @Test
+    fun ` save reservation test `() {
+        presenter.saveReservation()
+
+        verify(view).closeScreen()
+    }
+}


### PR DESCRIPTION
-Added MVP files for the dialog fragment date and time selector 
-Added unitesting for the presenter classes of the reservation activity as well as for the dialog fragment

Project file tree:
![image](https://user-images.githubusercontent.com/84336381/127196154-cc42e0c4-5453-4dca-85f0-e369c54b9764.png)

Testing coveraje:
![image](https://user-images.githubusercontent.com/84336381/127196513-fa89c742-1787-4987-aaa4-01e9a185863a.png)

Demo Pixel 3a:
https://user-images.githubusercontent.com/84336381/127197329-e59a5098-42d7-4947-b966-dd370dccbc17.mp4

Demo  Nexus S
https://user-images.githubusercontent.com/84336381/127197626-9f283886-4522-4421-94e1-f36f0745baf9.mp4